### PR TITLE
feat(9): 메인페이지 각 요소 배치

### DIFF
--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -1,0 +1,24 @@
+import FortuneCard from "@/features/fortuneWidget/ui/FortuneCard";
+import ChallengeSlider from "@/features/main/ui/ChallengeSlider";
+import StampSlider from "@/features/main/ui/StampSlider";
+import UserCard from "@/features/qrScanner/ui/UserCard";
+import Header from "@/shared/ui/Header";
+
+
+export default function MainPage() {
+  return (
+    <div>
+      <Header />
+      <div className="flex flex-col mt-[30px] justify-center items-center gap-[20px]">
+        <FortuneCard />
+        <UserCard />
+
+      </div>
+      <div className="flex flex-col gap-[40px] mt-[40px] p-4">
+        <StampSlider />
+        <ChallengeSlider />
+      </div>
+      
+    </div>
+  );
+}

--- a/src/shared/ui/Header.tsx
+++ b/src/shared/ui/Header.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 
 export default function Header() {
   return (
-    <header className="relative h-[50px] z-[1000] bg-[#FBFBEE] max-w-[375px] mx-auto pt-[44px]">
+    <header className="relative h-[50px] bg-[#FBFBEE] max-w-[375px] mx-auto pt-[44px]">
       <div className="px-2 h-full flex items-center">
         <div className="flex items-center pl-4">
           <Image 


### PR DESCRIPTION
## 🔎 작업 내용

- 메인페이지 각 컴포넌트 배치

- 헤더안에서 불필요한 코드를 제거했습니다.

  <br/>

## 이미지 첨부

![Uploading Kapture 2025-04-08 at 15.32.47.gif…]()

<br/>

## 🔧 앞으로의 과제

- 스탬프북 페이지 (리스트로 보기/지도로 보기) 구현


  <br/>

## ➕ 이슈 링크

- [feat] 메인페이지 UI 구현 #9

<br/>
