### PR TITLE
fix(37) : 월활한 스캔을 위한 QR 조정

### DIFF
--- a/src/app/owner/qrscan/page.tsx
+++ b/src/app/owner/qrscan/page.tsx
@@ -6,7 +6,6 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useQRStore } from "@/shared/store";
 
-
 export default function QrScanPage() {
   const [isScanning, setIsScanning] = useState(false);
   // const [scanResult, setScanResult] = useState<string | null>(null);
@@ -41,7 +40,7 @@ export default function QrScanPage() {
     if (isScanning) {
       setScannedUuid(result);
       setIsScanning(false);
-      router.push('/customer');
+      router.push("/customer");
     }
   };
 
@@ -49,7 +48,7 @@ export default function QrScanPage() {
     setIsScanning(false);
     // 뒤로가기 실행
     setTimeout(() => {
-      router.back();
+      router.push("/owner/main");
     }, 100);
   };
 
@@ -63,11 +62,7 @@ export default function QrScanPage() {
         <QrScanHeader title="프로필 QR 스캔" onExit={handleExit} />
       </div>
       <div className="flex-1">
-        <QrScanner
-          onScan={handleScan}
-          onError={handleError}
-          isScanning={isScanning}
-        />
+        <QrScanner onScan={handleScan} onError={handleError} isScanning={isScanning} />
       </div>
       <div className="absolute bottom-0 left-0 right-0">
         <OwnerGNB />

--- a/src/features/owner/ui/QRScanner.tsx
+++ b/src/features/owner/ui/QRScanner.tsx
@@ -67,10 +67,11 @@ export function QrScanner({ onScan, onError, isScanning }: QrScannerProps) {
     const startScanner = async () => {
       try {
         const devices = await BrowserQRCodeReader.listVideoInputDevices();
+
+        const backCamera = devices.find(device => device.label.toLowerCase().includes("back"));
+
         if (devices.length === 0) throw new Error("No camera found");
-
-        const selectedDeviceId = devices[0].deviceId;
-
+        const selectedDeviceId = backCamera?.deviceId ?? devices[0].deviceId;
         await codeReader.current?.decodeFromVideoDevice(
           selectedDeviceId,
           videoRef.current!,

--- a/src/shared/ui/modal/QrSection.tsx
+++ b/src/shared/ui/modal/QrSection.tsx
@@ -1,5 +1,6 @@
 import { SilhouetteColor } from "@/shared/model";
 import { getScanCharacter } from "@/shared/utils";
+import Image from "next/image";
 import { QRCodeCanvas } from "qrcode.react";
 
 interface QrSectionProps {
@@ -10,10 +11,15 @@ interface QrSectionProps {
 function QrSection({ uuid, color }: QrSectionProps) {
   const characterUrl = getScanCharacter(color);
   return (
-    <div className="relative flex flex-col items-center">
-      <img src={characterUrl} alt="scan-character" className="absolute top-[-30px]" />
-      <img src="/img/qr-section.svg" alt="qr-section" />
-      <QRCodeCanvas value={uuid} size={110} className="absolute top-6" />
+    <div className="relative flex flex-col items-center w-full">
+      <Image
+        src={characterUrl}
+        alt="scan-character"
+        className="absolute top-[-200px]"
+        width={200}
+        height={200}
+      />
+      <QRCodeCanvas value={uuid} size={200} className="absolute top-[-120px]" />
     </div>
   );
 }


### PR DESCRIPTION

## 🔎 작업 내용

- qr코드의 크기를 200으로 조정합니다.
- qr코드의 인식을 방해하는 배경 요소를 제거합니다.

  <br/>

## 이미지 첨부
x
<br/>

## 🔧 앞으로의 과제

- 스탬프 적립 api 연동
- 사장 페이지 api 연동

  <br/>

## ➕ 이슈 링크

- #37 

<br/>
